### PR TITLE
Use static, dependabot-parseable forms in gemspec

### DIFF
--- a/ice_age.gemspec
+++ b/ice_age.gemspec
@@ -1,16 +1,14 @@
 require_relative "lib/ice_age/version"
 
-package = IceAge
-
 Gem::Specification.new do |s|
   s.authors     = ['Daniel Pepper']
   s.description = 'Freeze your ENVironment for testing.'
   s.files       = `git ls-files * ':!:spec'`.split("\n")
   s.homepage    = 'https://github.com/dpep/ice_age_rb'
   s.license     = 'MIT'
-  s.name        = File.basename(__FILE__).split(".")[0]
-  s.summary     = package.to_s
-  s.version     = package.const_get('VERSION')
+  s.name        = 'ice_age'
+  s.summary     = 'IceAge'
+  s.version     = IceAge::VERSION
 
   s.required_ruby_version = '>= 3.2'
 


### PR DESCRIPTION
## Summary

Dependabot's gemspec parser is **static** — it doesn't eval Ruby, it reads the AST and only handles literal `s.name = "string"` and `s.version = SomeConst::VERSION`. The dynamic forms we had defeated that.

When dependabot can't extract the version statically it falls back to `0.0.1` and writes that into `Gemfile.lock`, which then fails CI in frozen mode (gem version mismatch). See dpep/meddleware_rb#18 for the original diagnosis.

This PR switches to the canonical Bundler-scaffold shape:

```ruby
s.name    = "ice_age"
s.version = IceAge::VERSION
```


## Test plan

- [x] `Bundler.load_gemspec("ice_age.gemspec")` parses statically to name=`ice_age`, version=`0.2.0`
- [x] `bundle install` runs cleanly

## Pattern reference

- dpep/meddleware_rb#18 (diagnosis)
- dpep/amenable_rb#7 (template)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
